### PR TITLE
Modify Colorshift class

### DIFF
--- a/scripts/whiteboxgan.py
+++ b/scripts/whiteboxgan.py
@@ -89,10 +89,11 @@ class ColorShift(nn.Module):
     # Sample the random color shift coefficients
     weights = self.dist.sample()
 
-    # images * weights[None, :, None, None] => Apply weights to r,g,b channels of each images
+    # images * self.weights[None, :, None, None] => Apply weights to r,g,b channels of each images
     # torch.sum(, dim=1) => Sum along the channels so (B, 3, H, W) become (B, H, W)
     # .unsqueeze(1) => add back the channel so (B, H, W) become (B, 1, H, W)
-    return ((((torch.sum(images * weights[None, :, None, None], dim= 1)) / weights.sum()).unsqueeze(1)) for images in image_batches)
+    # .repeat(1, 3, 1, 1) => (B, 1, H, W) become (B, 3, H, W) again
+    return ((((torch.sum(images * self.weights[None, :, None, None], dim= 1)) / self.weights.sum()).unsqueeze(1)).repeat(1, 3, 1, 1) for images in image_batches)
 
 
 class VariationLoss(nn.Module):

--- a/scripts/whiteboxgan.py
+++ b/scripts/whiteboxgan.py
@@ -93,7 +93,7 @@ class ColorShift(nn.Module):
     # torch.sum(, dim=1) => Sum along the channels so (B, 3, H, W) become (B, H, W)
     # .unsqueeze(1) => add back the channel so (B, H, W) become (B, 1, H, W)
     # .repeat(1, 3, 1, 1) => (B, 1, H, W) become (B, 3, H, W) again
-    return ((((torch.sum(images * self.weights[None, :, None, None], dim= 1)) / self.weights.sum()).unsqueeze(1)).repeat(1, 3, 1, 1) for images in image_batches)
+    return ((((torch.sum(images * weights[None, :, None, None], dim= 1)) / weights.sum()).unsqueeze(1)).repeat(1, 3, 1, 1) for images in image_batches)
 
 
 class VariationLoss(nn.Module):


### PR DESCRIPTION
The colorshift algorithm in this repo does not seem to be correct. The tensor returned is different from the official tensorflow result.

A simple code experiment:
```python
import torch
dist = torch.distributions.Uniform(
      torch.tensor((0.199, 0.487, 0.014)),
      torch.tensor((0.399, 0.687, 0.214)))

weights = dist.sample()
print(weights)

input = torch.randn(1,3,2,2)
print(input)

result1 = (input[0][0] * weights[0] + input[0][1] * weights[1] + input[0][2] * weights[2]) #/ weights.sum()
print(result1)
#print(result1.shape) # (1, 1, 2, 2)

result3 = (input * weights[None, :, None, None]) #/ weights.sum)
print(result3)
#print(result3.shape) # (1, 3, 2, 2)
```

Output:
```
tensor([0.3578, 0.4892, 0.1649])
tensor([[[[-0.1037, -0.8086],
          [ 0.8238,  0.1194]],

         [[-1.7902,  0.8636],
          [ 0.6097,  0.2215]],

         [[ 2.1408, -0.3082],
          [-1.9271,  0.5686]]]])
tensor([[-0.5599,  0.0824],
        [ 0.2752,  0.2448]])
torch.Size([2, 2])
tensor([[[[-0.0371, -0.2893],
          [ 0.2947,  0.0427]],

         [[-0.8759,  0.4225],
          [ 0.2983,  0.1084]],

         [[ 0.3531, -0.0508],
          [-0.3178,  0.0938]]]])
torch.Size([1, 3, 2, 2])
```

I believe the channels need to be added together.

Old:
![color_shift_wrong](https://user-images.githubusercontent.com/34955859/153132276-7b9326e4-3162-4b9b-baea-5cf8207008ad.png)

New:
![color_shift](https://user-images.githubusercontent.com/34955859/153132307-6a0bdb28-9faa-42f5-8644-89e997a361dc.png)

